### PR TITLE
feat(vpn): add freebox_vpn_server and freebox_vpn_user resources

### DIFF
--- a/internal/provider.go
+++ b/internal/provider.go
@@ -124,6 +124,8 @@ func (p *freeboxProvider) Resources(ctx context.Context) []func() resource.Resou
 		NewVirtualDiskResource,
 		NewVirtualMachineResource,
 		NewPortForwardingResource,
+		NewVPNServerResource,
+		NewVPNUserResource,
 	}
 }
 

--- a/internal/resource_vpn_server.go
+++ b/internal/resource_vpn_server.go
@@ -1,0 +1,226 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/nikolalohinski/free-go/client"
+	freeboxTypes "github.com/nikolalohinski/free-go/types"
+)
+
+var (
+	_ resource.ResourceWithImportState = &vpnServerResource{}
+)
+
+func NewVPNServerResource() resource.Resource {
+	return &vpnServerResource{}
+}
+
+type vpnServerResource struct {
+	client client.Client
+}
+
+type vpnServerModel struct {
+	ID         types.String `tfsdk:"id"`
+	Enabled    types.Bool   `tfsdk:"enabled"`
+	ServerPort types.Int64  `tfsdk:"server_port"`
+	ServerIP   types.String `tfsdk:"server_ip"`
+	ServerMask types.String `tfsdk:"server_mask"`
+	PushDHCP   types.Bool   `tfsdk:"push_dhcp"`
+	CA         types.String `tfsdk:"ca"`
+}
+
+func (m *vpnServerModel) toPayload() freeboxTypes.OpenVPNServerConfig {
+	payload := freeboxTypes.OpenVPNServerConfig{
+		Enabled:    m.Enabled.ValueBool(),
+		ServerPort: m.ServerPort.ValueInt64(),
+		PushDHCP:   m.PushDHCP.ValueBool(),
+	}
+	if !m.ServerIP.IsNull() && !m.ServerIP.IsUnknown() {
+		payload.ServerIP = m.ServerIP.ValueString()
+	}
+	if !m.ServerMask.IsNull() && !m.ServerMask.IsUnknown() {
+		payload.ServerMask = m.ServerMask.ValueString()
+	}
+	return payload
+}
+
+func (m *vpnServerModel) fromClientType(config freeboxTypes.OpenVPNServerConfig) {
+	m.ID = basetypes.NewStringValue("openvpn")
+	m.Enabled = basetypes.NewBoolValue(config.Enabled)
+	m.ServerPort = basetypes.NewInt64Value(config.ServerPort)
+	m.ServerIP = basetypes.NewStringValue(config.ServerIP)
+	m.ServerMask = basetypes.NewStringValue(config.ServerMask)
+	m.PushDHCP = basetypes.NewBoolValue(config.PushDHCP)
+	m.CA = basetypes.NewStringValue(config.CA)
+}
+
+func (v *vpnServerResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_vpn_server"
+}
+
+func (v *vpnServerResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Manages the OpenVPN server configuration on the Freebox. This is a singleton resource: only one OpenVPN server exists per Freebox. Destroying this resource disables the VPN server.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Fixed identifier for the singleton OpenVPN server resource",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"enabled": schema.BoolAttribute{
+				MarkdownDescription: "Whether the OpenVPN server is enabled",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(true),
+			},
+			"server_port": schema.Int64Attribute{
+				MarkdownDescription: "UDP port the OpenVPN server listens on (default 1194)",
+				Optional:            true,
+				Computed:            true,
+				Default:             int64default.StaticInt64(1194),
+			},
+			"server_ip": schema.StringAttribute{
+				MarkdownDescription: "VPN subnet IP address (e.g. \"10.8.0.0\")",
+				Optional:            true,
+				Computed:            true,
+			},
+			"server_mask": schema.StringAttribute{
+				MarkdownDescription: "VPN subnet mask (e.g. \"255.255.255.0\")",
+				Optional:            true,
+				Computed:            true,
+			},
+			"push_dhcp": schema.BoolAttribute{
+				MarkdownDescription: "Whether to push DHCP settings to clients",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+			},
+			"ca": schema.StringAttribute{
+				MarkdownDescription: "CA certificate in PEM format (read-only, set by Freebox)",
+				Computed:            true,
+				Sensitive:           true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (v *vpnServerResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	c, ok := req.ProviderData.(client.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	v.client = c
+}
+
+func (v *vpnServerResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var model vpnServerModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	response, err := v.client.UpdateOpenVPNServerConfig(ctx, model.toPayload())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to configure OpenVPN server",
+			err.Error(),
+		)
+		return
+	}
+
+	model.fromClientType(response)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+}
+
+func (v *vpnServerResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var model vpnServerModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	response, err := v.client.GetOpenVPNServerConfig(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to read OpenVPN server config",
+			err.Error(),
+		)
+		return
+	}
+
+	model.fromClientType(response)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+}
+
+func (v *vpnServerResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var model vpnServerModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	response, err := v.client.UpdateOpenVPNServerConfig(ctx, model.toPayload())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to update OpenVPN server config",
+			err.Error(),
+		)
+		return
+	}
+
+	model.fromClientType(response)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+}
+
+func (v *vpnServerResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var model vpnServerModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	payload := model.toPayload()
+	payload.Enabled = false
+
+	if _, err := v.client.UpdateOpenVPNServerConfig(ctx, payload); err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to disable OpenVPN server",
+			err.Error(),
+		)
+	}
+}
+
+func (v *vpnServerResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), "openvpn")...)
+}

--- a/internal/resource_vpn_user.go
+++ b/internal/resource_vpn_user.go
@@ -1,0 +1,236 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/nikolalohinski/free-go/client"
+	freeboxTypes "github.com/nikolalohinski/free-go/types"
+)
+
+var (
+	_ resource.ResourceWithImportState = &vpnUserResource{}
+)
+
+func NewVPNUserResource() resource.Resource {
+	return &vpnUserResource{}
+}
+
+type vpnUserResource struct {
+	client client.Client
+}
+
+type vpnUserModel struct {
+	Login       types.String `tfsdk:"login"`
+	Password    types.String `tfsdk:"password"`
+	Description types.String `tfsdk:"description"`
+	OVPNConfig  types.String `tfsdk:"ovpn_config"`
+}
+
+func (m *vpnUserModel) toPayload() freeboxTypes.VPNUserPayload {
+	return freeboxTypes.VPNUserPayload{
+		Login:       m.Login.ValueString(),
+		Password:    m.Password.ValueString(),
+		Description: m.Description.ValueString(),
+	}
+}
+
+func (m *vpnUserModel) fromClientType(user freeboxTypes.VPNUser) {
+	m.Login = basetypes.NewStringValue(user.Login)
+	// Password is write-only on the Freebox API; preserve the value from config
+	if user.Description != "" {
+		m.Description = basetypes.NewStringValue(user.Description)
+	} else {
+		m.Description = basetypes.NewStringNull()
+	}
+}
+
+func (v *vpnUserResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_vpn_user"
+}
+
+func (v *vpnUserResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Manages a VPN user account on the Freebox OpenVPN server. The `ovpn_config` attribute contains the ready-to-use OpenVPN client configuration file content.",
+		Attributes: map[string]schema.Attribute{
+			"login": schema.StringAttribute{
+				MarkdownDescription: "VPN username (immutable after creation)",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"password": schema.StringAttribute{
+				MarkdownDescription: "VPN password",
+				Required:            true,
+				Sensitive:           true,
+			},
+			"description": schema.StringAttribute{
+				MarkdownDescription: "Optional description of the VPN user",
+				Optional:            true,
+			},
+			"ovpn_config": schema.StringAttribute{
+				MarkdownDescription: "OpenVPN client configuration file content (.ovpn format). Ready to import into any OpenVPN client.",
+				Computed:            true,
+				Sensitive:           true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (v *vpnUserResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	c, ok := req.ProviderData.(client.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	v.client = c
+}
+
+func (v *vpnUserResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var model vpnUserModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	user, err := v.client.CreateVPNUser(ctx, model.toPayload())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to create VPN user",
+			err.Error(),
+		)
+		return
+	}
+
+	model.fromClientType(user)
+
+	ovpnConfig, err := v.client.GetVPNUserClientConfig(ctx, model.Login.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to get VPN client config",
+			err.Error(),
+		)
+		return
+	}
+
+	model.OVPNConfig = basetypes.NewStringValue(ovpnConfig)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+}
+
+func (v *vpnUserResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var model vpnUserModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	user, err := v.client.GetVPNUser(ctx, model.Login.ValueString())
+	if err != nil {
+		if err == client.ErrVPNUserNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Failed to read VPN user",
+			err.Error(),
+		)
+		return
+	}
+
+	model.fromClientType(user)
+
+	ovpnConfig, err := v.client.GetVPNUserClientConfig(ctx, model.Login.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to get VPN client config",
+			err.Error(),
+		)
+		return
+	}
+
+	model.OVPNConfig = basetypes.NewStringValue(ovpnConfig)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+}
+
+func (v *vpnUserResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var model vpnUserModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Preserve the existing ovpn_config from state (it only changes when the server config changes)
+	var state vpnUserModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	user, err := v.client.UpdateVPNUser(ctx, model.Login.ValueString(), model.toPayload())
+	if err != nil {
+		if err == client.ErrVPNUserNotFound {
+			resp.Diagnostics.AddError(
+				"VPN user not found",
+				fmt.Sprintf("VPN user %q was not found on the Freebox. It may have been deleted outside of Terraform.", model.Login.ValueString()),
+			)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Failed to update VPN user",
+			err.Error(),
+		)
+		return
+	}
+
+	model.fromClientType(user)
+	model.OVPNConfig = state.OVPNConfig
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+}
+
+func (v *vpnUserResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var model vpnUserModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := v.client.DeleteVPNUser(ctx, model.Login.ValueString()); err != nil {
+		if err == client.ErrVPNUserNotFound {
+			return // Already deleted, nothing to do
+		}
+		resp.Diagnostics.AddError(
+			"Failed to delete VPN user",
+			err.Error(),
+		)
+	}
+}
+
+func (v *vpnUserResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("login"), req.ID)...)
+}


### PR DESCRIPTION
## Summary

- Adds `freebox_vpn_server` resource to manage the Freebox built-in OpenVPN server (singleton — enabled, port, subnet). Destroying the resource disables the VPN server.
- Adds `freebox_vpn_user` resource to manage VPN user accounts. Exposes the ready-to-use `.ovpn` client config as a sensitive computed attribute `ovpn_config`.
- Registers both resources in the provider.

## Dependencies

This PR depends on **holyhope/free-go#<N>** (`feat/vpn-openvpn`) being merged and released first. The `go.mod` currently has a local `replace` directive for development:
```
replace github.com/nikolalohinski/free-go => /path/to/local/free-go-vpn
```
Once the `free-go` PR is merged and tagged, this replace directive must be removed and the `free-go` version bumped accordingly.

- [ ] After merging free-go PR: bump the `free-go` version

🤖 Generated with [Claude Code](https://claude.com/claude-code)