### PR TITLE
fix(resource/vpn_user): stop refetching ovpn_config on every Read

### DIFF
--- a/internal/resource_vpn_user.go
+++ b/internal/resource_vpn_user.go
@@ -136,6 +136,8 @@ func (v *vpnUserResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
+	existingOVPNConfig := model.OVPNConfig
+
 	user, err := v.client.GetVPNUser(ctx, model.Login.ValueString())
 	if err != nil {
 		if err == client.ErrVPNUserNotFound {
@@ -151,16 +153,26 @@ func (v *vpnUserResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	model.fromClientType(user)
 
-	ovpnConfig, err := v.client.GetVPNUserClientConfig(ctx, model.Login.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Failed to get VPN client config",
-			err.Error(),
-		)
-		return
-	}
+	// The Freebox API embeds a freshly generated certificate in the response
+	// on every call to GetVPNUserClientConfig, so re-fetching here would make
+	// ovpn_config look like it changes on every refresh even though the
+	// server-side config is stable (it only changes when the user is
+	// recreated). Preserve the value already in state, same as Update does,
+	// and only fetch it when state doesn't have one yet (e.g. after import).
+	if existingOVPNConfig.ValueString() != "" {
+		model.OVPNConfig = existingOVPNConfig
+	} else {
+		ovpnConfig, err := v.client.GetVPNUserClientConfig(ctx, model.Login.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Failed to get VPN client config",
+				err.Error(),
+			)
+			return
+		}
 
-	model.OVPNConfig = basetypes.NewStringValue(ovpnConfig)
+		model.OVPNConfig = basetypes.NewStringValue(ovpnConfig)
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
 }

--- a/internal/resource_vpn_user_test.go
+++ b/internal/resource_vpn_user_test.go
@@ -1,0 +1,104 @@
+package internal_test
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/nikolalohinski/free-go/client"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe(`resource "freebox_vpn_user" { ... }`, func() {
+	var (
+		resourceName string
+		login        string
+		password     string
+		config       string
+	)
+
+	BeforeEach(func(ctx SpecContext) {
+		splitName := strings.Split(("test-" + uuid.New().String())[:30], "-")
+		resourceName = strings.Join(splitName[:len(splitName)-1], "-")
+		login = resourceName
+		password = uuid.New().String()
+	})
+
+	JustBeforeEach(func(ctx SpecContext) {
+		config = providerBlock + `
+			resource "freebox_vpn_user" "` + resourceName + `" {
+				login    = "` + login + `"
+				password = "` + password + `"
+			}
+		`
+	})
+
+	Context("create and delete", func() {
+		It("should create and delete the VPN user", func(ctx SpecContext) {
+			resource.UnitTest(GinkgoT(), resource.TestCase{
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check: resource.ComposeAggregateTestCheckFunc(
+							resource.TestCheckResourceAttr("freebox_vpn_user."+resourceName, "login", login),
+							resource.TestCheckResourceAttrSet("freebox_vpn_user."+resourceName, "ovpn_config"),
+							func(s *terraform.State) error {
+								_, err := freeboxClient.GetVPNUser(ctx, login)
+								Expect(err).To(BeNil())
+								return nil
+							},
+						),
+					},
+				},
+				CheckDestroy: func(s *terraform.State) error {
+					_, err := freeboxClient.GetVPNUser(ctx, login)
+					Expect(errors.Is(err, client.ErrVPNUserNotFound)).To(BeTrue(), "expected VPN user to be deleted, got: %v", err)
+					return nil
+				},
+			})
+		})
+	})
+
+	Context("refreshing state", func() {
+		It("should not report ovpn_config as changed across a refresh", func(ctx SpecContext) {
+			// The Freebox API embeds a freshly generated certificate in the
+			// response every time GetVPNUserClientConfig is called, even when
+			// nothing about the VPN user changed. Read must not blindly
+			// re-fetch and overwrite ovpn_config on every refresh, or this
+			// resource (and anything consuming its ovpn_config output, e.g. a
+			// downstream OpenVPN client profile) would be forced to replace
+			// on every single terraform apply.
+			var firstOVPNConfig string
+
+			resource.UnitTest(GinkgoT(), resource.TestCase{
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check: func(s *terraform.State) error {
+							firstOVPNConfig = s.RootModule().Resources["freebox_vpn_user."+resourceName].Primary.Attributes["ovpn_config"]
+							Expect(firstOVPNConfig).ToNot(BeEmpty())
+							return nil
+						},
+					},
+					{
+						RefreshState: true,
+						Check: func(s *terraform.State) error {
+							Expect(s.RootModule().Resources["freebox_vpn_user."+resourceName].Primary.Attributes["ovpn_config"]).To(Equal(firstOVPNConfig))
+							return nil
+						},
+					},
+					{
+						Config:             config,
+						PlanOnly:           true,
+						ExpectNonEmptyPlan: false,
+					},
+				},
+			})
+		})
+	})
+})


### PR DESCRIPTION
## Summary
- The Freebox API embeds a freshly generated certificate in the response of `GetVPNUserClientConfig` on every call, even when the VPN user itself hasn't changed.
- `Read()` was unconditionally re-fetching and overwriting `ovpn_config` on every refresh, making the attribute look like it drifts on every single `terraform plan`/`apply` and forcing any downstream resource consuming it (e.g. an OpenVPN client profile) to be replaced every time.
- `Read()` now preserves the existing `ovpn_config` from state, same as `Update()` already does, and only fetches it when state has none yet (e.g. right after import).

Stacked on #67 (drops the fictional `description` field this same resource file currently references) — this PR's diff is scoped to the `ovpn_config` drift fix only.

Verified the root cause live against a real Freebox: created a temporary VPN user, called `GetVPNUserClientConfig` twice in a row, and confirmed the returned config differs between calls (then deleted the temp user).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -list` (new test file type-checks)
- [x] Manually confirmed against a live Freebox that `GetVPNUserClientConfig` returns a different cert on each call
- [ ] Full acceptance suite (`go test ./internal/...`) — not run here; this repo's `BeforeSuite` expects a pre-existing `Freebox` root folder and downloads a VM image, which didn't match the Freebox available in this environment